### PR TITLE
Fix back icon issue

### DIFF
--- a/lib/ui/sign_in/sign_in_view_model.dart
+++ b/lib/ui/sign_in/sign_in_view_model.dart
@@ -61,12 +61,12 @@ class SignInViewModel extends BaseViewModel {
   String getError() => _error;
 
   Future navigateToSignUp() async {
-    await _navigationService.navigateTo(Routes.signUpView);
+    await _navigationService.replaceWith(Routes.signUpView);
     notifyListeners();
   }
 
   Future _navigateToHome() async {
-    await _navigationService.replaceWith(Routes.userHomeView);
+    await _navigationService.clearStackAndShow(Routes.userHomeView);
     notifyListeners();
   }
 }

--- a/lib/ui/sign_up/sign_up_view_model.dart
+++ b/lib/ui/sign_up/sign_up_view_model.dart
@@ -57,12 +57,12 @@ class SignUpViewModel extends BaseViewModel {
   String getError() => _error;
 
   Future _navigateToHome() async {
-    await _navigationService.replaceWith(Routes.userHomeView);
+    await _navigationService.clearStackAndShow(Routes.userHomeView);
     notifyListeners();
   }
 
   Future navigateToSignIn() async {
-    await _navigationService.navigateTo(Routes.signInView);
+    await _navigationService.replaceWith(Routes.signInView);
     notifyListeners();
   }
 }


### PR DESCRIPTION
Upon getting to the home route after signing in/signing up, there was a back icon that pops the view stack. Now, the back icon has been removed. Tapping the device back icon will cause the user to exit the app instead